### PR TITLE
Feat : JWT 응답 DTO에 memberId 및 memberRole 추가

### DIFF
--- a/src/main/java/com/example/tastefulai/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/example/tastefulai/domain/member/service/MemberServiceImpl.java
@@ -79,7 +79,7 @@ public class MemberServiceImpl implements MemberService {
         // RefreshToken 을 Redis 에 저장
         storeRefreshToken(email, refreshToken);
 
-        return new JwtAuthResponse(accessToken, refreshToken);
+        return new JwtAuthResponse(member.getId(), member.getMemberRole(), accessToken, refreshToken);
     }
 
 

--- a/src/main/java/com/example/tastefulai/global/common/dto/JwtAuthResponse.java
+++ b/src/main/java/com/example/tastefulai/global/common/dto/JwtAuthResponse.java
@@ -1,14 +1,20 @@
 package com.example.tastefulai.global.common.dto;
 
+import com.example.tastefulai.domain.member.enums.MemberRole;
 import lombok.Getter;
 
 @Getter
 public class JwtAuthResponse {
 
+    private final Long memberId;
+    private final MemberRole memberRole;
     private final String accessToken;
     private final String refreshToken;
 
-    public JwtAuthResponse(String accessToken, String refreshToken) {
+    public JwtAuthResponse(Long memberId, MemberRole memberRole, String accessToken, String refreshToken) {
+
+        this.memberId = memberId;
+        this.memberRole = memberRole;
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
     }


### PR DESCRIPTION
Feat: JWT 응답 DTO에 memberId 및 memberRole 추가

- JwtAuthResponse DTO에 memberId와 memberRole 필드 추가
- 로그인 시 사용자 식별 정보(memberId)와 권한(memberRole) 반환하도록 변경
- 기존 accessToken, refreshToken만 포함되던 구조에서 확장됨